### PR TITLE
Remove DoInitialize from SetStartTime

### DIFF
--- a/src/applications/model/msg-generator-app.cc
+++ b/src/applications/model/msg-generator-app.cc
@@ -148,7 +148,6 @@ void MsgGeneratorApp::Start (Time start)
   NS_LOG_FUNCTION (this);
     
   SetStartTime(start);
-  DoInitialize();
 }
     
 void MsgGeneratorApp::Stop (Time stop)


### PR DESCRIPTION
Removed DoInitialize call during start time setting as it is redundant. Bug #10